### PR TITLE
feat(clickup): add ClickUp to Dust import script

### DIFF
--- a/clickup/README.md
+++ b/clickup/README.md
@@ -1,0 +1,90 @@
+# ClickUp to Dust Datasource Import
+
+This script imports ClickUp data into a Dust datasource.
+Supported data types:
+
+### Doc pages
+The script imports doc pages from ClickUp.
+It fetches all pages and subpages for a given `docId`at once, then formats and uploads this data to a specified Dust datasource.
+
+## Installation
+
+1. Ensure you have Node.js (version 14 or higher) and npm installed on your system.
+
+2. Clone this repository:
+   ```
+   git clone git@github.com:dust-tt/dust-labs.git
+   cd dust-labs/clickup
+   ```
+
+3. Install the dependencies:
+   ```
+   npm install
+   ```
+
+## Environment Setup
+
+Create a `.env` file in the root directory of the project with the following variables:
+
+```
+# source
+CLICKUP_API_KEY=your_clickup_api_key
+CLICKUP_WORKSPACE_ID=your_clickup_space_id
+CLICKUP_DOC_ID=the_doc_id_you_want_to_import
+
+# destination
+DUST_API_KEY=your_dust_api_key
+DUST_WORKSPACE_ID=your_dust_workspace_id
+DUST_DATASOURCE_ID=your_dust_datasource_id
+```
+
+Replace the placeholder values with your actual ClickUp and Dust settings.
+
+## Usage
+
+To run the script:
+
+*To import a given Doc Page (and subpages) from ClickUp's Knowledge Base:*
+```
+npm run docs
+```
+
+## How It Works
+
+1. The script fetches all the page and subpages for a given `DocId` using ClickUp's API.
+2. The collected data is then upserted to the specified Dust datasource, using the page ID as the document ID.
+
+## Error Handling
+
+The script includes error handling for rate limiting. If a rate limit is exceeded, it will wait before retrying the request.
+
+## Building
+
+To compile the TypeScript code to JavaScript:
+
+```
+npm run build
+```
+
+This will create a `dist` directory with the compiled JavaScript files.
+
+## Dependencies
+
+- axios: For making HTTP requests to Zendesk and Dust APIs
+- dotenv: For loading environment variables
+- slugify: For generating slugs from page titles
+
+## Dev Dependencies
+
+- @types/node: TypeScript definitions for Node.js
+- tsx: For running TypeScript files directly
+- typescript: The TypeScript compiler
+
+## Notes
+
+- Ensure you have the necessary permissions in both ClickUp and Dust to perform these operations.
+- The Dust datasource must be created manually though the web UI.
+
+## License
+
+This project is licensed under the ISC License.

--- a/clickup/clickup-docs-to-dust.ts
+++ b/clickup/clickup-docs-to-dust.ts
@@ -1,0 +1,171 @@
+import axios, { AxiosResponse } from 'axios';
+import * as dotenv from 'dotenv';
+import Bottleneck from 'bottleneck';
+import slugify from 'slugify';
+
+dotenv.config();
+
+// source
+const CLICKUP_API_KEY = process.env.CLICKUP_API_KEY;
+const CLICKUP_WORKSPACE_ID = process.env.CLICKUP_WORKSPACE_ID;
+const CLICKUP_DOC_ID = process.env.CLICKUP_DOC_ID;
+
+// destination
+const DUST_API_KEY = process.env.DUST_API_KEY;
+const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
+const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
+
+const missingEnvVars = [
+  ['CLICKUP_API_KEY', CLICKUP_API_KEY],
+  ['CLICKUP_WORKSPACE_ID', CLICKUP_WORKSPACE_ID],
+  ['CLICKUP_DOC_ID', CLICKUP_DOC_ID],
+  ['DUST_API_KEY', DUST_API_KEY],
+  ['DUST_WORKSPACE_ID', DUST_WORKSPACE_ID],
+  ['DUST_DATASOURCE_ID', DUST_DATASOURCE_ID]
+].filter(([name, value]) => !value).map(([name]) => name);
+
+if (missingEnvVars.length > 0) {
+  throw new Error(`Please provide values for the following environment variables in the .env file: ${missingEnvVars.join(', ')}`);
+}
+
+const clickupApi = axios.create({
+  baseURL: 'https://api.clickup.com/api/v3',
+  headers: {
+    'Authorization': CLICKUP_API_KEY,
+    'Content-Type': 'application/json'
+  },
+  maxContentLength: Infinity,
+  maxBodyLength: Infinity
+});
+
+clickupApi.interceptors.response.use(
+  (response) => {
+    console.log(`Endpoint: ${response.config.url}, Status: ${response.status}`);
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.status === 429) {
+      console.error(`Endpoint: ${error.config.url}, Rate limit exceeded. Please wait before making more requests.`);
+    }
+    return Promise.reject(error);
+  }
+);
+
+// Create a Bottleneck limiter for Dust API
+const dustLimiter = new Bottleneck({
+  minTime: 500, // 500ms between requests
+  maxConcurrent: 1, // Only 1 request at a time
+});
+
+const dustApi = axios.create({
+  baseURL: 'https://dust.tt/api/v1',
+  headers: {
+    'Authorization': `Bearer ${DUST_API_KEY}`,
+    'Content-Type': 'application/json'
+  },
+  maxContentLength: Infinity,
+  maxBodyLength: Infinity
+});
+
+// Wrap dustApi.post with the limiter
+const limitedDustApiPost = dustLimiter.wrap(
+  (url: string, data: any, config?: any) => dustApi.post(url, data, config)
+);
+
+interface ClickUpPage {
+  workspace_id: string;
+  doc_id: string;
+  id: string;
+  archived: boolean;
+  name: string;
+  content: string;
+  parent_id: string | null;
+  pages: ClickUpPage[];
+  date_created: number;
+  date_updated: number;
+}
+
+function generateSlug(name: string): string {
+  return slugify(name, {
+    lower: true,
+    strict: true,
+    trim: true
+  });
+}
+
+async function getClickUpPages(docId: string): Promise<ClickUpPage[]> {
+  try {
+    const response: AxiosResponse<ClickUpPage[]> = await clickupApi.get(
+      `/workspaces/${CLICKUP_WORKSPACE_ID}/docs/${docId}/pages`,
+      {
+        params: {
+          max_page_depth: -1,
+          content_format: 'text/md'
+        }
+      }
+    );
+    console.log(`Retrieved ${response.data.length} pages from ClickUp`);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching ClickUp pages:', error);
+    throw error;
+  }
+}
+
+async function upsertToDustDatasource(page: ClickUpPage) {
+  const slug = generateSlug(page.name);
+  const documentId = `${page.id}-${slug}`;
+  const createdDate = new Date(page.date_created).toISOString();
+  const updatedDate = new Date(page.date_updated).toISOString();
+
+  const content = `
+Title: ${page.name}
+Created At: ${createdDate}
+Updated At: ${updatedDate}
+Content:
+${page.content}
+  `.trim();
+
+  try {
+    await limitedDustApiPost(
+      `/w/${DUST_WORKSPACE_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+      {
+        text: content,
+        source_url: `https://app.clickup.com/${CLICKUP_WORKSPACE_ID}/v/dc/${CLICKUP_DOC_ID}/${page.id}`
+      }
+    );
+    console.log(`Upserted page '${documentId}' https://app.clickup.com/${CLICKUP_WORKSPACE_ID}/v/dc/${CLICKUP_DOC_ID}/${page.id} to Dust datasource`);
+  } catch (error) {
+    console.error(`Error upserting page '${documentId}') to Dust datasource:`, error);
+  }
+}
+
+async function processPages(pages: ClickUpPage[]) {
+  for (const page of pages) {
+
+    // skip empty pages
+    if (page.content && page.content.trim() !== '') {
+      if (!page.archived) {
+        await upsertToDustDatasource(page);
+      } else {
+        console.log(`Skipping archived page: ${page.name}`);
+      }
+    }
+
+    if (page.pages && page.pages.length > 0) {
+      await processPages(page.pages);
+    }
+  }
+}
+
+async function main() {
+  try {
+    const pages = await getClickUpPages(CLICKUP_DOC_ID!);
+    await processPages(pages);
+    console.log('All pages processed successfully.');
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
+}
+
+main();

--- a/clickup/clickup-docs-to-dust.ts
+++ b/clickup/clickup-docs-to-dust.ts
@@ -14,6 +14,7 @@ const CLICKUP_DOC_ID = process.env.CLICKUP_DOC_ID;
 const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
 const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
+const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
 
 const missingEnvVars = [
   ['CLICKUP_API_KEY', CLICKUP_API_KEY],
@@ -21,7 +22,8 @@ const missingEnvVars = [
   ['CLICKUP_DOC_ID', CLICKUP_DOC_ID],
   ['DUST_API_KEY', DUST_API_KEY],
   ['DUST_WORKSPACE_ID', DUST_WORKSPACE_ID],
-  ['DUST_DATASOURCE_ID', DUST_DATASOURCE_ID]
+  ['DUST_DATASOURCE_ID', DUST_DATASOURCE_ID],
+  ['DUST_VAULT_ID', DUST_VAULT_ID]
 ].filter(([name, value]) => !value).map(([name]) => name);
 
 if (missingEnvVars.length > 0) {
@@ -128,7 +130,7 @@ ${page.content}
 
   try {
     await limitedDustApiPost(
-      `/w/${DUST_WORKSPACE_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+      `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
       {
         text: content,
         source_url: `https://app.clickup.com/${CLICKUP_WORKSPACE_ID}/v/dc/${CLICKUP_DOC_ID}/${page.id}`

--- a/clickup/package.json
+++ b/clickup/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "clickup-to-dust",
+  "version": "0.1.0",
+  "description": "Script to import ClickUp data to Dust datasources",
+  "main": "index.ts",
+  "scripts": {
+    "docs": "tsx clickup-docs-to-dust.ts",
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^1.4.0",
+    "bottleneck": "^2.19.5",
+    "dotenv": "^16.0.3",
+    "slugify": "^1.6.6"
+  },
+  "devDependencies": {
+    "@types/node": "^18.16.3",
+    "tsx": "^4.19.1",
+    "typescript": "^5.0.4"
+  }
+}


### PR DESCRIPTION
This script is inspired by the `zendesk/import-script/zendesk-articles-to-dust` script.

It allows to import docs from `ClickUp.com` into Dust.

See details in the README.md file.