### PR TITLE
Update modjo import script

### DIFF
--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -89,6 +89,10 @@ async function getModjoTranscripts(): Promise<ModjoCallExport[]> {
   let page = 1;
   const perPage = 50;
 
+  console.log(
+    `Will retrieve all transcripts since: ${TRANSCRIPTS_SINCE}`
+  );
+
   do {
     try {
       const response: AxiosResponse<{

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -11,6 +11,7 @@ const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
 const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
 const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
 const INCLUDE_CONTACT_DETAILS = process.env.INCLUDE_CONTACT_DETAILS !== 'false';
+const INCLUDE_RECORDING_URL = process.env.INCLUDE_RECORDING_URL !== 'false';
 
 if (
   !MODJO_API_KEY ||
@@ -98,7 +99,8 @@ async function getModjoTranscripts(): Promise<ModjoCallExport[]> {
 
   console.log(
     `Will retrieve all transcripts since: ${TRANSCRIPTS_SINCE}\n` +
-    `Will include contact details: ${INCLUDE_CONTACT_DETAILS}`
+    `Will include contact details: ${INCLUDE_CONTACT_DETAILS}\n` +
+    `Will include recording URLs: ${INCLUDE_RECORDING_URL}`
   );
 
   do {
@@ -158,7 +160,7 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
   content += `Provider: ${transcript.provider}\n`;
   content += `Language: ${transcript.language}\n`;
   if (transcript.callCrmId) content += `CRM ID: ${transcript.callCrmId}\n`;
-  if (transcript.relations.recording)
+  if (INCLUDE_RECORDING_URL && transcript.relations.recording)
     content += `Recording URL: ${transcript.relations.recording.url}\n`;
 
 

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -183,6 +183,7 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
         `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
         {
           text: content.trim(),
+          source_url: `https://app.modjo.ai/call-details/${transcript.callId}`,
         }
       )
     );

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -8,16 +8,18 @@ const MODJO_BASE_URL = process.env.MODJO_BASE_URL || "https://api.modjo.ai";
 const MODJO_API_KEY = process.env.MODJO_API_KEY;
 const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
+const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
 const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
 
 if (
   !MODJO_API_KEY ||
   !DUST_API_KEY ||
   !DUST_WORKSPACE_ID ||
+  !DUST_VAULT_ID ||
   !DUST_DATASOURCE_ID
 ) {
   throw new Error(
-    "Please provide values for MODJO_API_KEY, DUST_API_KEY, DUST_WORKSPACE_ID, and DUST_DATASOURCE_ID in .env file."
+    "Please provide values for MODJO_API_KEY, DUST_API_KEY, DUST_WORKSPACE_ID, DUST_VAULT_ID, and DUST_DATASOURCE_ID in .env file."
   );
 }
 
@@ -173,7 +175,7 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
   try {
     await limiter.schedule(() =>
       dustApi.post(
-        `/w/${DUST_WORKSPACE_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+        `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
         {
           text: content.trim(),
         }

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -65,7 +65,7 @@ interface ModjoCallExport {
     recording: {
       url: string;
     };
-    aiSummary: {
+    highlights: {
       content: string;
     } | null;
     speakers: {
@@ -113,7 +113,7 @@ async function getModjoTranscripts(): Promise<ModjoCallExport[]> {
         },
         relations: {
           recording: true,
-          aiSummary: true,
+          highlights: true,
           transcript: true,
           speakers: true,
         },
@@ -162,8 +162,8 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
     content += "\n";
   });
 
-  if (transcript.relations.aiSummary)
-    content += `\n# AI Summary\n${transcript.relations.aiSummary.content.trim()}\n`;
+  if (transcript.relations.highlights)
+    content += `\n# Highlights\n${transcript.relations.highlights.content.trim()}\n`;
 
   content += "\n# Transcript\n";
   transcript.relations.transcript.forEach((entry) => {

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -10,6 +10,7 @@ const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
 const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
 const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
+const INCLUDE_CONTACT_DETAILS = process.env.INCLUDE_CONTACT_DETAILS !== 'false';
 
 if (
   !MODJO_API_KEY ||
@@ -96,7 +97,8 @@ async function getModjoTranscripts(): Promise<ModjoCallExport[]> {
   const perPage = 50;
 
   console.log(
-    `Will retrieve all transcripts since: ${TRANSCRIPTS_SINCE}`
+    `Will retrieve all transcripts since: ${TRANSCRIPTS_SINCE}\n` +
+    `Will include contact details: ${INCLUDE_CONTACT_DETAILS}`
   );
 
   do {
@@ -163,8 +165,10 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
   content += "\n# Speakers\n";
   transcript.relations.speakers.forEach((speaker) => {
     content += `${speaker.speakerId}: ${speaker.name} (${speaker.type})`;
-    if (speaker.email) content += ` - Email: ${speaker.email}`;
-    if (speaker.phoneNumber) content += ` - Phone: ${speaker.phoneNumber}`;
+    if (INCLUDE_CONTACT_DETAILS) {
+      if (speaker.email) content += ` - Email: ${speaker.email}`;
+      if (speaker.phoneNumber) content += ` - Phone: ${speaker.phoneNumber}`;
+    }
     content += "\n";
   });
 

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -65,7 +65,9 @@ interface ModjoCallExport {
     recording: {
       url: string;
     };
-    aiSummary: string | null;
+    aiSummary: {
+      content: string;
+    } | null;
     speakers: {
       contactId?: number;
       userId?: number;
@@ -152,7 +154,7 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
   if (transcript.relations.recording)
     content += `Recording URL: ${transcript.relations.recording.url}\n`;
   if (transcript.relations.aiSummary)
-    content += `AI Summary: ${transcript.relations.aiSummary}\n`;
+    content += `AI Summary: ${transcript.relations.aiSummary.content}\n`;
 
   content += "\nSpeakers:\n";
   transcript.relations.speakers.forEach((speaker) => {

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -24,7 +24,8 @@ if (
 }
 
 // Can be `null` if you want to fetch all transcripts
-const TRANSCRIPTS_SINCE = process.env.TRANSCRIPTS_SINCE === "null" ? null : (process.env.TRANSCRIPTS_SINCE || "2024-01-01");
+const YESTERDAY = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+const TRANSCRIPTS_SINCE = process.env.TRANSCRIPTS_SINCE === "null" ? null : (process.env.TRANSCRIPTS_SINCE || YESTERDAY);
 
 const modjoApi = axios.create({
   baseURL: MODJO_BASE_URL,

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -84,6 +84,9 @@ interface ModjoCallExport {
       content: string;
       topics: { topicId: number; name: string }[];
     }[];
+    tags: {
+      name: string;
+    }[];
   };
 }
 
@@ -116,6 +119,7 @@ async function getModjoTranscripts(): Promise<ModjoCallExport[]> {
           highlights: true,
           transcript: true,
           speakers: true,
+          tags: true,
         },
       });
 
@@ -145,6 +149,7 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
   const documentId = `modjo-transcript-${transcript.callId}`;
 
   let content = `Call ID: ${transcript.callId}\n`;
+  content += `Tags: ${transcript.relations.tags.map(tag => `"${tag.name}"`).join(', ') }\n`;
   content += `Title: ${transcript.title}\n`;
   content += `Date: ${transcript.startDate}\n`;
   content += `Duration: ${transcript.duration} seconds\n`;
@@ -153,6 +158,7 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
   if (transcript.callCrmId) content += `CRM ID: ${transcript.callCrmId}\n`;
   if (transcript.relations.recording)
     content += `Recording URL: ${transcript.relations.recording.url}\n`;
+
 
   content += "\n# Speakers\n";
   transcript.relations.speakers.forEach((speaker) => {

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -153,10 +153,8 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
   if (transcript.callCrmId) content += `CRM ID: ${transcript.callCrmId}\n`;
   if (transcript.relations.recording)
     content += `Recording URL: ${transcript.relations.recording.url}\n`;
-  if (transcript.relations.aiSummary)
-    content += `AI Summary: ${transcript.relations.aiSummary.content}\n`;
 
-  content += "\nSpeakers:\n";
+  content += "\n# Speakers\n";
   transcript.relations.speakers.forEach((speaker) => {
     content += `${speaker.speakerId}: ${speaker.name} (${speaker.type})`;
     if (speaker.email) content += ` - Email: ${speaker.email}`;
@@ -164,7 +162,10 @@ async function upsertToDustDatasource(transcript: ModjoCallExport) {
     content += "\n";
   });
 
-  content += "\nTranscript:\n";
+  if (transcript.relations.aiSummary)
+    content += `\n# AI Summary\n${transcript.relations.aiSummary.content.trim()}\n`;
+
+  content += "\n# Transcript\n";
   transcript.relations.transcript.forEach((entry) => {
     const speaker = transcript.relations.speakers.find(
       (s) => s.speakerId === entry.speakerId

--- a/modjo/modjo-transcripts-to-dust.ts
+++ b/modjo/modjo-transcripts-to-dust.ts
@@ -24,7 +24,7 @@ if (
 }
 
 // Can be `null` if you want to fetch all transcripts
-const TRANSCRIPTS_SINCE = "2024-01-01";
+const TRANSCRIPTS_SINCE = process.env.TRANSCRIPTS_SINCE === "null" ? null : (process.env.TRANSCRIPTS_SINCE || "2024-01-01");
 
 const modjoApi = axios.create({
   baseURL: MODJO_BASE_URL,

--- a/modjo/readme.md
+++ b/modjo/readme.md
@@ -27,6 +27,7 @@ This script imports Modjo call transcripts into a Dust datasource. It fetches tr
    DUST_DATASOURCE_ID=your_dust_datasource_id
 
    # TRANSCRIPTS_SINCE=YYYY-MM-DD # or "null" if you want to fetch all transcripts
+   # INCLUDE_CONTACT_DETAILS=true # or "false" to skip contact details
    ```
    Replace the placeholder values with your actual API keys and IDs.
 
@@ -43,6 +44,7 @@ This command executes the `modjo-transcripts-to-dust.ts` file using `ts-node`.
 ## Configuration
 
 - `TRANSCRIPTS_SINCE`: You can set this environment variable to a date string (e.g., "2024-01-01") to fetch transcripts from that date onwards. Set it to `null` to fetch all transcripts.
+- `INCLUDE_CONTACT_DETAILS`: Set this environment variable to `false` if you don't want to ingest contact details (ie: email and phone number) in Dust.
 
 ## What the Script Does
 

--- a/modjo/readme.md
+++ b/modjo/readme.md
@@ -28,6 +28,7 @@ This script imports Modjo call transcripts into a Dust datasource. It fetches tr
 
    # TRANSCRIPTS_SINCE=YYYY-MM-DD # or "null" if you want to fetch all transcripts
    # INCLUDE_CONTACT_DETAILS=true # or "false" to skip contact details
+   # INCLUDE_RECORDING_URL=true # or "false" if you don't want the recording URL to appear in Dust
    ```
    Replace the placeholder values with your actual API keys and IDs.
 
@@ -45,6 +46,7 @@ This command executes the `modjo-transcripts-to-dust.ts` file using `ts-node`.
 
 - `TRANSCRIPTS_SINCE`: You can set this environment variable to a date string (e.g., "2024-01-01") to fetch transcripts from that date onwards. Set it to `null` to fetch all transcripts.
 - `INCLUDE_CONTACT_DETAILS`: Set this environment variable to `false` if you don't want to ingest contact details (ie: email and phone number) in Dust.
+- `INCLUDE_RECORDING_URL`: Set this environment variable to `false` if you don't want to ingest the recording URL in Dust.
 
 ## What the Script Does
 

--- a/modjo/readme.md
+++ b/modjo/readme.md
@@ -25,6 +25,8 @@ This script imports Modjo call transcripts into a Dust datasource. It fetches tr
    DUST_WORKSPACE_ID=your_dust_workspace_id
    DUST_VAULT_ID=your_dust_vault_id
    DUST_DATASOURCE_ID=your_dust_datasource_id
+
+   # TRANSCRIPTS_SINCE=YYYY-MM-DD # or "null" if you want to fetch all transcripts
    ```
    Replace the placeholder values with your actual API keys and IDs.
 
@@ -40,7 +42,7 @@ This command executes the `modjo-transcripts-to-dust.ts` file using `ts-node`.
 
 ## Configuration
 
-- `TRANSCRIPTS_SINCE`: In the script, you can set this variable to a date string (e.g., "2024-01-01") to fetch transcripts from that date onwards. Set it to `null` to fetch all transcripts.
+- `TRANSCRIPTS_SINCE`: You can set this environment variable to a date string (e.g., "2024-01-01") to fetch transcripts from that date onwards. Set it to `null` to fetch all transcripts.
 
 ## What the Script Does
 

--- a/modjo/readme.md
+++ b/modjo/readme.md
@@ -23,6 +23,7 @@ This script imports Modjo call transcripts into a Dust datasource. It fetches tr
    MODJO_API_KEY=your_modjo_api_key
    DUST_API_KEY=your_dust_api_key
    DUST_WORKSPACE_ID=your_dust_workspace_id
+   DUST_VAULT_ID=your_dust_vault_id
    DUST_DATASOURCE_ID=your_dust_datasource_id
    ```
    Replace the placeholder values with your actual API keys and IDs.

--- a/modjo/readme.md
+++ b/modjo/readme.md
@@ -70,7 +70,7 @@ This command executes the `modjo-transcripts-to-dust.ts` file using `ts-node`.
 Each transcript is formatted as follows in the Dust datasource:
 
 1. Call metadata (ID, title, date, duration, etc.)
-2. Recording URL and AI summary (if available)
+2. Recording URL and highlights (if available)
 3. List of speakers with their details
 4. Full transcript with timestamps, speaker names, and topics
 


### PR DESCRIPTION
# What

We wanted to import Modjo transcripts in Dust and saw this existing script. However, it didn't entirely fit our needs, so we made a few improvements.

This PR includes small fixes:
- chore(modjo): update Dust datasource endpoint
- fix(modjo): correctly render AI Summary in Dust document
- chore(modjo): Use new 'Highlights' API field

Along with additional features:
- feat(modjo): make recording URL optional
- feat(modjo): add option to skip ingestion of contacts' details
- feat(modjo): render conversation tags to dust documents
- chore(modjo): specify source_url when creating Dust documents

# Notes for reviewers

@albandum, the `TRANSCRIPTS_SINCE` was hardcoded within the script itself, which wasn't convenient if we wanted to tweak its value in the context of a scheduled job.
We made it configurable through environment variables, and introduced a _small_ breaking change: by default, the script would ingest every transcript since yesterday, not since `2024-01-01`.

I guess it is a matter of preference, so I'll understand if you prefer to keep the existing behavior: I can amend the PR.

- BREAKING CHANGE - chore(modjo): by default, fetch transcripts since yesterday
- feat(modjo): make the TRANSCRIPTS_SINCE configurable via env var