### PR TITLE
Fix import script for zendesk-articles 

### DIFF
--- a/zendesk/import-script/readme.md
+++ b/zendesk/import-script/readme.md
@@ -36,8 +36,12 @@ ZENDESK_EMAIL=your_zendesk_email
 ZENDESK_API_TOKEN=your_zendesk_api_token
 DUST_API_KEY=your_dust_api_key
 DUST_WORKSPACE_ID=your_dust_workspace_id
-DUST_VAULT_ID=your_dust_vault_id
-DUST_DATASOURCE_ID=your_dust_datasource_id
+
+DUST_VAULT_ID_FOR_ARTICLES=your_dust_vault_id_for_articles
+DUST_DATASOURCE_ID_FOR_ARTICLES=your_dust_datasource_id_for_articles
+
+DUST_VAULT_ID_FOR_TICKETS=your_dust_vault_id_for_tickets
+DUST_DATASOURCE_ID_FOR_TICKETS=your_dust_datasource_id_for_tickets
 ```
 
 Replace the placeholder values with your actual Zendesk and Dust credentials.

--- a/zendesk/import-script/readme.md
+++ b/zendesk/import-script/readme.md
@@ -36,6 +36,7 @@ ZENDESK_EMAIL=your_zendesk_email
 ZENDESK_API_TOKEN=your_zendesk_api_token
 DUST_API_KEY=your_dust_api_key
 DUST_WORKSPACE_ID=your_dust_workspace_id
+DUST_VAULT_ID=your_dust_vault_id
 DUST_DATASOURCE_ID=your_dust_datasource_id
 ```
 

--- a/zendesk/import-script/zendesk-articles-to-dust.ts
+++ b/zendesk/import-script/zendesk-articles-to-dust.ts
@@ -9,6 +9,7 @@ const ZENDESK_EMAIL = process.env.ZENDESK_EMAIL;
 const ZENDESK_API_TOKEN = process.env.ZENDESK_API_TOKEN;
 const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
+const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
 const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
 
 const missingEnvVars = [
@@ -17,6 +18,7 @@ const missingEnvVars = [
   ['ZENDESK_API_TOKEN', ZENDESK_API_TOKEN],
   ['DUST_API_KEY', DUST_API_KEY],
   ['DUST_WORKSPACE_ID', DUST_WORKSPACE_ID],
+  ['DUST_VAULT_ID', DUST_VAULT_ID],
   ['DUST_DATASOURCE_ID', DUST_DATASOURCE_ID]
 ].filter(([name, value]) => !value).map(([name]) => name);
 
@@ -163,7 +165,7 @@ ${article.body}
 
   try {
     await limitedDustApiPost(
-      `/w/${DUST_WORKSPACE_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+      `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
       {
         text: content,
         source_url: article.html_url

--- a/zendesk/import-script/zendesk-articles-to-dust.ts
+++ b/zendesk/import-script/zendesk-articles-to-dust.ts
@@ -9,8 +9,8 @@ const ZENDESK_EMAIL = process.env.ZENDESK_EMAIL;
 const ZENDESK_API_TOKEN = process.env.ZENDESK_API_TOKEN;
 const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
-const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
-const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
+const DUST_VAULT_ID_FOR_ARTICLES = process.env.DUST_VAULT_ID_FOR_ARTICLES;
+const DUST_DATASOURCE_ID_FOR_ARTICLES = process.env.DUST_DATASOURCE_ID_FOR_ARTICLES;
 
 const missingEnvVars = [
   ['ZENDESK_SUBDOMAIN', ZENDESK_SUBDOMAIN],
@@ -18,8 +18,8 @@ const missingEnvVars = [
   ['ZENDESK_API_TOKEN', ZENDESK_API_TOKEN],
   ['DUST_API_KEY', DUST_API_KEY],
   ['DUST_WORKSPACE_ID', DUST_WORKSPACE_ID],
-  ['DUST_VAULT_ID', DUST_VAULT_ID],
-  ['DUST_DATASOURCE_ID', DUST_DATASOURCE_ID]
+  ['DUST_VAULT_ID_FOR_ARTICLES', DUST_VAULT_ID_FOR_ARTICLES],
+  ['DUST_DATASOURCE_ID_FOR_ARTICLES', DUST_DATASOURCE_ID_FOR_ARTICLES]
 ].filter(([name, value]) => !value).map(([name]) => name);
 
 if (missingEnvVars.length > 0) {
@@ -166,7 +166,7 @@ ${article.body}
 
   try {
     await limitedDustApiPost(
-      `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+      `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID_FOR_ARTICLES}/data_sources/${DUST_DATASOURCE_ID_FOR_ARTICLES}/documents/${documentId}`,
       {
         text: content,
         source_url: article.html_url

--- a/zendesk/import-script/zendesk-tickets-to-dust.ts
+++ b/zendesk/import-script/zendesk-tickets-to-dust.ts
@@ -9,6 +9,7 @@ const ZENDESK_EMAIL = process.env.ZENDESK_EMAIL;
 const ZENDESK_API_TOKEN = process.env.ZENDESK_API_TOKEN;
 const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
+const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
 const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
 
 const missingEnvVars = [
@@ -17,6 +18,7 @@ const missingEnvVars = [
   ["ZENDESK_API_TOKEN", ZENDESK_API_TOKEN],
   ["DUST_API_KEY", DUST_API_KEY],
   ["DUST_WORKSPACE_ID", DUST_WORKSPACE_ID],
+  ["DUST_VAULT_ID", DUST_VAULT_ID],
   ["DUST_DATASOURCE_ID", DUST_DATASOURCE_ID],
 ]
   .filter(([name, value]) => !value)
@@ -283,7 +285,7 @@ ${comment.body}
 
   try {
     await limitedDustApiPost(
-      `/w/${DUST_WORKSPACE_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+      `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
       {
         text: content,
         source_url: `https://${ZENDESK_SUBDOMAIN}.zendesk.com/agent/tickets/${ticket.id}`,

--- a/zendesk/import-script/zendesk-tickets-to-dust.ts
+++ b/zendesk/import-script/zendesk-tickets-to-dust.ts
@@ -9,8 +9,8 @@ const ZENDESK_EMAIL = process.env.ZENDESK_EMAIL;
 const ZENDESK_API_TOKEN = process.env.ZENDESK_API_TOKEN;
 const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
-const DUST_VAULT_ID = process.env.DUST_VAULT_ID;
-const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
+const DUST_VAULT_ID_FOR_TICKETS = process.env.DUST_VAULT_ID_FOR_TICKETS;
+const DUST_DATASOURCE_ID_FOR_TICKETS = process.env.DUST_DATASOURCE_ID_FOR_TICKETS;
 
 const missingEnvVars = [
   ["ZENDESK_SUBDOMAIN", ZENDESK_SUBDOMAIN],
@@ -18,8 +18,8 @@ const missingEnvVars = [
   ["ZENDESK_API_TOKEN", ZENDESK_API_TOKEN],
   ["DUST_API_KEY", DUST_API_KEY],
   ["DUST_WORKSPACE_ID", DUST_WORKSPACE_ID],
-  ["DUST_VAULT_ID", DUST_VAULT_ID],
-  ["DUST_DATASOURCE_ID", DUST_DATASOURCE_ID],
+  ["DUST_VAULT_ID_FOR_TICKETS", DUST_VAULT_ID_FOR_TICKETS],
+  ["DUST_DATASOURCE_ID_FOR_TICKETS", DUST_DATASOURCE_ID_FOR_TICKETS],
 ]
   .filter(([name, value]) => !value)
   .map(([name]) => name);
@@ -285,7 +285,7 @@ ${comment.body}
 
   try {
     await limitedDustApiPost(
-      `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+      `/w/${DUST_WORKSPACE_ID}/vaults/${DUST_VAULT_ID_FOR_TICKETS}/data_sources/${DUST_DATASOURCE_ID_FOR_TICKETS}/documents/${documentId}`,
       {
         text: content,
         source_url: `https://${ZENDESK_SUBDOMAIN}.zendesk.com/agent/tickets/${ticket.id}`,


### PR DESCRIPTION
# What
fix(zendesk-articles): fix pagination

# Why
As per the Zendesk API docs, the `next_page` field
is a URL that includes the `page` query parameter.

This means that the params `{page: nextPage}` would never be valid.
I suspect that the initial idea was to use the `currentPage` variable that is incremented on each iteration of the loop.

In this commit, I'm fixing that logic and get rid of the `nextPage` variable that is no longer needed.

[1]: https://developer.zendesk.com/api-reference/introduction/pagination/#using-offset-pagination

# Notes

Since the pagination wasn't working as expected, when running the script, it would do an _infinite loop_ fetching again and again the same page, until we get an _out of memory_ error:

```
Endpoint: /help_center/articles.json, Rate Limit: 2500, Remaining: 2498
Retrieved 30 articles. Total: 38400
Fetching articles page: 1281
<--- Last few GCs --->
[131:0x7ae29c250000]   464751 ms: Mark-Compact 4032.0 (4147.3) -> 4026.9 (4143.0) MB, pooled: 0 MB, 42.86 / 0.00 ms  (average mu = 0.900, current mu = 0.879) allocation failure; scavenge might not succeed
[131:0x7ae29c250000]   464849 ms: Mark-Compact 4028.5 (4144.3) -> 4028.5 (4144.8) MB, pooled: 0 MB, 95.42 / 0.00 ms  (average mu = 0.739, current mu = 0.027) allocation failure; scavenge might not succeed
<--- JS stacktrace --->
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----
```