### PR TITLE
Add script to sync list of assistants in a Notion database

### DIFF
--- a/notion/README.md
+++ b/notion/README.md
@@ -42,6 +42,11 @@ To run the script:
 npm run sync-list-of-assistants-to-notion-database
 ```
 
+## How It Works
+
+1. The script fetches all the assistants in a given Dust workspace.
+2. It configures the Notion database with some predefined properties (see [Notes](#notes) bellow)
+
 ## Dependencies
 
 - axios: For making HTTP requests to Zendesk and Dust APIs
@@ -52,6 +57,11 @@ npm run sync-list-of-assistants-to-notion-database
 - @types/node: TypeScript definitions for Node.js
 - tsx: For running TypeScript files directly
 - typescript: The TypeScript compiler
+
+## Notes
+
+The Notion database must be created manually.
+We expect the database to be dedicated to this script. Therefore, the script will automatically configure the fields of the database.
 
 ## License
 

--- a/notion/README.md
+++ b/notion/README.md
@@ -1,0 +1,58 @@
+# Dust to Notion synchronisation
+
+This script synchronises the list of Dust assistants in a Notion database.
+
+## Installation
+
+1. Ensure you have Node.js (version 14 or higher) and npm installed on your system.
+
+2. Clone this repository:
+   ```
+   git clone git@github.com:dust-tt/dust-labs.git
+   cd dust-labs/notion
+   ```
+
+3. Install the dependencies:
+   ```
+   npm install --include=dev
+   ```
+
+## Environment Setup
+
+Create a `.env` file in the root directory of the project with the following variables:
+
+```
+# source
+DUST_API_KEY=your_dust_api_key
+DUST_WORKSPACE_ID=your_dust_workspace_id
+
+# destination
+NOTION_API_KEY=your_notion_api_key
+NOTION_DATABASE_ID=your_notion_database_id
+```
+
+Replace the placeholder values with your actual Dust and Notion settings.
+
+## Usage
+
+To run the script:
+
+*To synchronise the list of Dust assistants in a Notion database:*
+```
+npm run sync-list-of-assistants-to-notion-database
+```
+
+## Dependencies
+
+- axios: For making HTTP requests to Zendesk and Dust APIs
+- dotenv: For loading environment variables
+
+## Dev Dependencies
+
+- @types/node: TypeScript definitions for Node.js
+- tsx: For running TypeScript files directly
+- typescript: The TypeScript compiler
+
+## License
+
+This project is licensed under the ISC License.

--- a/notion/README.md
+++ b/notion/README.md
@@ -45,8 +45,9 @@ npm run sync-list-of-assistants-to-notion-database
 ## How It Works
 
 1. The script fetches all the assistants in a given Dust workspace.
-2. It configures the Notion database with some predefined properties (see [Notes](#notes) bellow)
-3. It upserts each assistant to the Notion database, using the `dust.name` property as the unique identifier.
+2. It fetches 30-day usage data for each assistant, including message count and user reach, integrating this with assistant information for a comprehensive overview.
+3. It configures the Notion database with some predefined properties (see [Notes](#notes) bellow)
+4. It upserts each assistant to the Notion database, using the `dust.name` property as the unique identifier.
 
 ## Dependencies
 

--- a/notion/README.md
+++ b/notion/README.md
@@ -46,6 +46,7 @@ npm run sync-list-of-assistants-to-notion-database
 
 1. The script fetches all the assistants in a given Dust workspace.
 2. It configures the Notion database with some predefined properties (see [Notes](#notes) bellow)
+3. It upserts each assistant to the Notion database, using the `dust.name` property as the unique identifier.
 
 ## Dependencies
 

--- a/notion/package.json
+++ b/notion/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dust-to-notion",
+  "version": "0.1.0",
+  "description": "Script to synchronise the list of Dust assistants in Notion",
+  "main": "index.ts",
+  "scripts": {
+    "sync-list-of-assistants-to-notion-database": "tsx sync-list-of-assistants-to-notion-database.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^1.4.0",
+    "dotenv": "^16.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^18.16.3",
+    "tsx": "^4.19.1",
+    "typescript": "^5.0.4"
+  }
+}

--- a/notion/package.json
+++ b/notion/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@notionhq/client": "^2.2.15",
     "axios": "^1.4.0",
     "dotenv": "^16.0.3"
   },

--- a/notion/package.json
+++ b/notion/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@notionhq/client": "^2.2.15",
     "axios": "^1.4.0",
+    "csv-parse": "^5.5.6",
     "dotenv": "^16.0.3"
   },
   "devDependencies": {

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -110,13 +110,13 @@ async function configureNotionDatabase() {
         'dust.id': { rich_text: {} },
         'dust.instructions': { rich_text: {} },
         'dust.maxStepsPerRun': { number: {} },
-        'dust.modelId': { select: {} },
-        'dust.modelProviderId': { select: {} },
+        ...(existingDatabaseConfig.properties['dust.modelId'] ? {} : { 'dust.modelId': { select: {} } }),
+        ...(existingDatabaseConfig.properties['dust.modelProviderId'] ? {} : { 'dust.modelProviderId': { select: {} } }),
         'dust.modelTemperature': { number: {} },
         'dust.pictureUrl': { url: {} },
-        'dust.scope': { select: {} },
+        ...(existingDatabaseConfig.properties['dust.scope'] ? {} : { 'dust.scope': { select: {} } }),
         'dust.sId': { rich_text: {} },
-        'dust.status': { select: {} },
+        ...(existingDatabaseConfig.properties['dust.status'] ? {} : { 'dust.status': { select: {} } }),
         'dust.visualizationEnabled': { checkbox: {} },
       }
     });

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -1,0 +1,30 @@
+import axios, { AxiosResponse } from 'axios';
+import * as dotenv from 'dotenv';
+
+
+dotenv.config();
+
+// source
+const DUST_API_KEY = process.env.DUST_API_KEY;
+const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
+
+// destination
+const NOTION_API_KEY = process.env.NOTION_API_KEY;
+const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID;
+
+const missingEnvVars = [
+  ['DUST_API_KEY', DUST_API_KEY],
+  ['DUST_WORKSPACE_ID', DUST_WORKSPACE_ID],
+  ['NOTION_API_KEY', NOTION_API_KEY],
+  ['NOTION_DATABASE_ID', NOTION_DATABASE_ID],
+].filter(([name, value]) => !value).map(([name]) => name);
+
+if (missingEnvVars.length > 0) {
+  throw new Error(`Please provide values for the following environment variables in the .env file: ${missingEnvVars.join(', ')}`);
+}
+
+async function main() {
+  console.log(`Syncing the list of Dust assistants from workspace ${DUST_WORKSPACE_ID} into Notion database ${NOTION_DATABASE_ID}`);
+}
+
+main();

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -105,6 +105,12 @@ async function configureNotionDatabase() {
   try {
     const response = await notion.databases.update({
       database_id: NOTION_DATABASE_ID ?? '',
+      description: [
+        { text: { content: "💡 All the ", } },
+        { text: { content: "dust.*", }, annotations: { "code": true, } },
+        { text: { content: " fields are automatically synced from Dust.tt. Last sync: ", } },
+        { text: { content: new Date().toLocaleString(), }, annotations: { code: true, } },
+      ],
       properties: {
         ...(existingDatabaseConfig.properties.Name ? { Name: { name: "dust.name"} } : {}), // Rename the 'Name' property to 'dust.name'
         ...(existingDatabaseConfig.properties.Tags ? { Tags: null } : {}), // Remove the 'Tags' property if it exists in the current configuration

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -232,7 +232,7 @@ async function upsertToNotion(assistant: any) {
     return response;
   } catch (error) {
     console.error(`Error processing assistant '${assistant.name}':`, error);
-    throw error;
+    return null;
   }
 }
 

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -120,6 +120,7 @@ async function configureNotionDatabase() {
         ...(existingDatabaseConfig.properties['dust.scope'] ? {} : { 'dust.scope': { select: {} } }),
         'dust.sId': { rich_text: {} },
         ...(existingDatabaseConfig.properties['dust.status'] ? {} : { 'dust.status': { select: {} } }),
+        'dust.url': { url: {} },
         'dust.visualizationEnabled': { checkbox: {} },
       }
     });
@@ -157,6 +158,7 @@ async function upsertToNotion(assistant: any) {
       'dust.scope': { select: { name: assistant.scope } },
       'dust.sId': { rich_text: [ { text: { content: assistant.sId } } ] },
       'dust.status': { select: { name: assistant.status } },
+      'dust.url': { url: `https://dust.tt/w/${DUST_WORKSPACE_ID}/assistant/new?assistant=${assistant.sId}` },
       'dust.visualizationEnabled': { checkbox: assistant.visualizationEnabled },
     }
 

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -134,8 +134,8 @@ async function upsertToNotion(assistant: any) {
     const existingPages = await notion.databases.query({
       database_id: NOTION_DATABASE_ID ?? '',
       filter: {
-        property: 'dust.name',
-        title: { equals: assistant.name }
+        property: 'dust.sId',
+        rich_text: { equals: assistant.sId }
       }
     });
 

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -38,6 +38,7 @@ interface DustAssistant {
   };
   status: string;
   maxStepsPerRun: number;
+  versionCreatedAt: string;
   visualizationEnabled: boolean;
   templateId: string;
 }
@@ -71,6 +72,7 @@ async function getDustAssistants(): Promise<DustAssistant[]> {
       model: assistant.model,
       status: assistant.status,
       maxStepsPerRun: assistant.maxStepsPerRun,
+      versionCreatedAt: assistant.versionCreatedAt,
       visualizationEnabled: assistant.visualizationEnabled,
       templateId: assistant.templateId,
     }));
@@ -109,6 +111,7 @@ async function configureNotionDatabase() {
         'dust.description': { rich_text: {} },
         'dust.id': { rich_text: {} },
         'dust.instructions': { rich_text: {} },
+        'dust.lastVersionCreatedAt': { date: {}, description: "Last time the assistant configuration has been updated." },
         'dust.maxStepsPerRun': { number: {} },
         ...(existingDatabaseConfig.properties['dust.modelId'] ? {} : { 'dust.modelId': { select: {} } }),
         ...(existingDatabaseConfig.properties['dust.modelProviderId'] ? {} : { 'dust.modelProviderId': { select: {} } }),
@@ -144,6 +147,7 @@ async function upsertToNotion(assistant: any) {
       'dust.description': { rich_text: [ { text: { content: assistant.description } } ] },
       'dust.id': { rich_text: [ { text: { content: assistant.id.toString() } } ] },
       'dust.instructions': { rich_text: [ { text: { content: (assistant.instructions || '').substring(0, 2000) } } ] },
+      'dust.lastVersionCreatedAt': { date: assistant.versionCreatedAt ? { start: assistant.versionCreatedAt } : null },
       'dust.maxStepsPerRun': { number: assistant.maxStepsPerRun },
       'dust.modelId': { select: { name: assistant.model.modelId } },
       'dust.modelProviderId': { select: { name: assistant.model.providerId } },

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -23,8 +23,78 @@ if (missingEnvVars.length > 0) {
   throw new Error(`Please provide values for the following environment variables in the .env file: ${missingEnvVars.join(', ')}`);
 }
 
+interface DustAssistant {
+  id: number;
+  sId: string;
+  scope: string;
+  name: string;
+  pictureUrl: string;
+  description: string;
+  instructions: string;
+  model: {
+    providerId: string;
+    modelId: string;
+    temperature: number;
+  };
+  status: string;
+  maxStepsPerRun: number;
+  visualizationEnabled: boolean;
+  templateId: string;
+}
+
+const dustApi = axios.create({
+  baseURL: 'https://dust.tt/api/v1',
+  headers: {
+    'Authorization': `Bearer ${DUST_API_KEY}`,
+    'Content-Type': 'application/json'
+  },
+  maxContentLength: Infinity,
+  maxBodyLength: Infinity,
+});
+
+async function getDustAssistants(): Promise<DustAssistant[]> {
+  try {
+
+    // Fetch list of assistants
+    const response: AxiosResponse<{
+      agentConfigurations: DustAssistant[];
+    }> = await dustApi.get(`/w/${DUST_WORKSPACE_ID}/assistant/agent_configurations`);
+
+    const assistants = response.data.agentConfigurations.map((assistant: DustAssistant) => ({
+      id: assistant.id,
+      sId: assistant.sId,
+      scope: assistant.scope,
+      name: assistant.name,
+      pictureUrl: assistant.pictureUrl,
+      description: assistant.description,
+      instructions: assistant.instructions,
+      model: assistant.model,
+      status: assistant.status,
+      maxStepsPerRun: assistant.maxStepsPerRun,
+      visualizationEnabled: assistant.visualizationEnabled,
+      templateId: assistant.templateId,
+    }));
+
+    return assistants;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      console.error('Error fetching Dust assistants:', error.response.data);
+    } else {
+      console.error('Error fetching Dust assistants:', error);
+    }
+    throw error;
+  }
+}
+
 async function main() {
   console.log(`Syncing the list of Dust assistants from workspace ${DUST_WORKSPACE_ID} into Notion database ${NOTION_DATABASE_ID}`);
+  try {
+    console.log(`Fetching the list of Dust assistants.`);
+    const assistants = await getDustAssistants();
+    console.log(`Found ${assistants.length} assistants.`);
+  } catch (error) {
+    console.error('An error occurred:', error);
+  }
 }
 
 main();


### PR DESCRIPTION
# What

Add script to sync list of assistants in a Notion database

# Why

We now have +200 assistants, and it's hard to manage them through the Dust.tt website.

We needed to sync the list of our assistants so we could easily leverage them in Dust, and enrich them with other operational data (eg: which team a given assistant belongs to).