### PR TITLE
feat(jira): allow jql query customization through env var

### DIFF
--- a/jira/jira-issues-to-dust.ts
+++ b/jira/jira-issues-to-dust.ts
@@ -4,9 +4,12 @@ import Bottleneck from "bottleneck";
 
 dotenv.config();
 
+const DEFAULT_JIRA_QUERY = "updated >= -24h ORDER BY updated DESC";
+
 const JIRA_SUBDOMAIN = process.env.JIRA_SUBDOMAIN;
 const JIRA_EMAIL = process.env.JIRA_EMAIL;
 const JIRA_API_TOKEN = process.env.JIRA_API_TOKEN;
+const JIRA_QUERY = process.env.JIRA_QUERY || DEFAULT_JIRA_QUERY;
 const DUST_API_KEY = process.env.DUST_API_KEY;
 const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
 const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
@@ -29,7 +32,6 @@ if (missingEnvVars.length > 0) {
 }
 
 const DUST_RATE_LIMIT = 120; // requests per minute
-const ISSUES_UPDATED_SINCE = "24h";
 
 const jiraApi = axios.create({
   baseURL: `https://${JIRA_SUBDOMAIN}.atlassian.net/rest/api/3`,
@@ -158,7 +160,7 @@ async function getIssuesUpdatedLast24Hours(): Promise<JiraIssue[]> {
   const makeRequest = async (retryCount = 0): Promise<AxiosResponse<JiraSearchResponse>> => {
     try {
       return await jiraApi.post("/search", {
-        jql: `updated >= -${ISSUES_UPDATED_SINCE} ORDER BY updated DESC`,
+        jql: JIRA_QUERY,
         startAt,
         maxResults,
         fields: [

--- a/jira/readme.md
+++ b/jira/readme.md
@@ -78,6 +78,7 @@ Create a `.env` file in the root directory of the project with the following var
 JIRA_SUBDOMAIN=your-jira-subdomain
 JIRA_EMAIL=your-jira-email
 JIRA_API_TOKEN=your-jira-api-token
+JIRA_QUERY=your-jira-query # optional, default is `updated >= -24h ORDER BY updated DESC`
 DUST_API_KEY=your-dust-api-key
 DUST_WORKSPACE_ID=your-dust-workspace-id
 DUST_DATASOURCE_ID=your-dust-datasource-id


### PR DESCRIPTION
Allow users to pass JIRA_QUERY env var to customize the call to JIRA. Useful when one need to narrow down the query, or test things locally.