### PR TITLE
Improve Notion sync script

### DIFF
--- a/notion/README.md
+++ b/notion/README.md
@@ -29,6 +29,9 @@ DUST_WORKSPACE_ID=your_dust_workspace_id
 # destination
 NOTION_API_KEY=your_notion_api_key
 NOTION_DATABASE_ID=your_notion_database_id
+
+# configurable behavior
+NOTION_SOFT_DELETE=true # will mark 'dust.status' as 'deleted' instead of deleting the page
 ```
 
 Replace the placeholder values with your actual Dust and Notion settings.

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -236,7 +236,7 @@ async function upsertToNotion(assistant: any) {
   }
 }
 
-async function deleteOrphanedPages(assistants: DustAssistant[]) {
+async function processOrphanedPages(assistants: DustAssistant[]) {
   console.log('Checking for orphaned pages in Notion database...');
   const existingAssistantSIds = new Set(assistants.map(a => a.sId));
 
@@ -282,7 +282,7 @@ async function main() {
       await upsertToNotion(assistant);
     }
 
-    await deleteOrphanedPages(assistants);
+    await processOrphanedPages(assistants);
 
     console.log('All assistants processed successfully.');
   } catch (error) {

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -113,6 +113,7 @@ async function getDustAssistants(): Promise<DustAssistant[]> {
           ...assistant,
           authorEmails: usage ? JSON.parse(usage.authorEmails) : [],
           messages: usage ? parseInt(usage.messages, 10) : 0,
+          distinctConversations: usage ? parseInt(usage.distinctConversations, 10) : 0,
           distinctUsersReached: usage ? parseInt(usage.distinctUsersReached, 10) : 0,
         };
       });
@@ -159,12 +160,13 @@ async function configureNotionDatabase() {
         ...(existingDatabaseConfig.properties.Tags ? { Tags: null } : {}), // Remove the 'Tags' property if it exists in the current configuration
         ...(existingDatabaseConfig.properties['dust.authors'] ? {} : { 'dust.authors': { multi_select: {} } }),
         'dust.description': { rich_text: {} },
+        'dust.distinctConversations': { number: {}, description: `Number of distinct conversations over the last 30 days.` },
         'dust.distinctUsersReached': { number: {}, description: `Number of distinct users over the last 30 days.` },
         'dust.id': { rich_text: {} },
         'dust.instructions': { rich_text: {} },
         'dust.lastVersionCreatedAt': { date: {}, description: "Last time the assistant configuration has been updated." },
         'dust.maxStepsPerRun': { number: {} },
-        'dust.messages': { number: {}, description: `Number of times the assistant was used over the last 30 days.` },
+        'dust.messages': { number: {}, description: `Number of messages the assistant has sent over the last 30 days.` },
         ...(existingDatabaseConfig.properties['dust.modelId'] ? {} : { 'dust.modelId': { select: {} } }),
         ...(existingDatabaseConfig.properties['dust.modelProviderId'] ? {} : { 'dust.modelProviderId': { select: {} } }),
         'dust.modelTemperature': { number: {} },
@@ -200,6 +202,7 @@ async function upsertToNotion(assistant: any) {
     const properties = {
       'dust.authors': { multi_select: assistant.authorEmails.map(author => ({ name: author })) },
       'dust.description': { rich_text: [ { text: { content: assistant.description } } ] },
+      'dust.distinctConversations': { number: assistant.distinctConversations },
       'dust.distinctUsersReached': { number: assistant.distinctUsersReached },
       'dust.id': { rich_text: [ { text: { content: assistant.id.toString() } } ] },
       'dust.instructions': { rich_text: [ { text: { content: (assistant.instructions || '').substring(0, 2000) } } ] },

--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -173,6 +173,7 @@ async function configureNotionDatabase() {
         'dust.sId': { rich_text: {} },
         ...(existingDatabaseConfig.properties['dust.status'] ? {} : { 'dust.status': { select: {} } }),
         'dust.url': { url: {} },
+        'dust.assistantDetailsUrl': { url: {} },
         'dust.visualizationEnabled': { checkbox: {} },
       }
     });
@@ -214,6 +215,7 @@ async function upsertToNotion(assistant: any) {
       'dust.sId': { rich_text: [ { text: { content: assistant.sId } } ] },
       'dust.status': { select: { name: assistant.status } },
       'dust.url': { url: `https://dust.tt/w/${DUST_WORKSPACE_ID}/assistant/new?assistant=${assistant.sId}` },
+      'dust.assistantDetailsUrl': { url: `https://dust.tt/w/${DUST_WORKSPACE_ID}/assistant/new?assistantDetails=${assistant.sId}` },
       'dust.visualizationEnabled': { checkbox: assistant.visualizationEnabled },
     }
 


### PR DESCRIPTION
# What
- feat(notion): add soft delete option
- feat(notion): add url to the 'assistant details' page
- feat(notion): log number of distinct conversations per assistant

# Why
We were initially deleting the pages from Notion
when an assistant was deleted in Dust.

However, we have realized that there are no triggers
in Notion automation when a page is deleted.

Therefore, this commit introduces a new environment
variable `NOTION_SOFT_DELETE` which, when set to
`true`, will mark the `dust.status` property as
`deleted` instead of deleting the page.

That would allow new workflows where we could notify
a given slack channel when an assistant is deleted
in Dust.

As a bonus, we're also adding two new properties:
- the URL to the assistant details page
- the number of distinct conversations