### PR TITLE
fix(notion): improve logic that handles orphaned pages

### DIFF
--- a/notion/sync-list-of-assistants-to-notion-database.ts
+++ b/notion/sync-list-of-assistants-to-notion-database.ts
@@ -250,6 +250,12 @@ async function processOrphanedPages(assistants: DustAssistant[], softDelete: boo
 
   for await (const page of iteratePaginatedAPI(notion.databases.query, {
     database_id: NOTION_DATABASE_ID ?? '',
+    filter: {
+      property: 'dust.status',
+      select: {
+        equals: 'active'
+      }
+    }
   })) {
     if ('properties' in page) {
       const sIdProp = page.properties['dust.sId'];


### PR DESCRIPTION
We're now only processing pages that have a
`dust.status` property set to `active`.

All 'inactive' assistants were already deleted
in the past. It doesn't make sense to process them.