### PR TITLE
Add script to sync Guru cards to data sources

### DIFF
--- a/guru/example.env
+++ b/guru/example.env
@@ -1,0 +1,12 @@
+# Guru API Credentials
+GURU_API_TOKEN=gku_xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+GURU_EMAIL=your.email@company.com
+
+# Dust API Credentials
+DUST_API_KEY=sk-xxxxxxxxxxxxxxxxxxxx
+DUST_WORKSPACE_ID=ws-xxxxxxxxx
+DUST_DATASOURCE_ID=ds-xxxxxxxxx
+
+# Rate Limiting Configuration
+DUST_RATE_LIMIT=100
+GURU_MAX_CONCURRENT=5

--- a/guru/guru-to-dust.ts
+++ b/guru/guru-to-dust.ts
@@ -1,0 +1,114 @@
+import axios from "axios";
+import * as dotenv from "dotenv";
+import Bottleneck from "bottleneck";
+import { Guru, GuruCard } from "./guru";
+
+dotenv.config();
+
+// Validate required environment variables
+const requiredEnvVars = [
+    'GURU_API_TOKEN',
+    'GURU_EMAIL',
+    'DUST_API_KEY',
+    'DUST_WORKSPACE_ID',
+    'DUST_DATASOURCE_ID',
+    'DUST_RATE_LIMIT',
+    'GURU_MAX_CONCURRENT'
+  ];
+  
+const missingEnvVars = requiredEnvVars.filter(varName => !process.env[varName]);
+if (missingEnvVars.length > 0) {
+  throw new Error(
+    `Please provide values for the following environment variables: ${missingEnvVars.join(', ')}`
+  );
+}
+
+const DUST_API_KEY = process.env.DUST_API_KEY;
+const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
+const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
+
+// Rate limiting configuration
+const DUST_RATE_LIMIT = parseInt(process.env.DUST_RATE_LIMIT as string);
+const GURU_MAX_CONCURRENT = parseInt(process.env.GURU_MAX_CONCURRENT as string);
+
+// Guru credentials from environment
+const GURU_EMAIL = process.env.GURU_EMAIL as string;
+const GURU_API_TOKEN = process.env.GURU_API_TOKEN as string;
+
+// Initialize Dust API client
+const dustApi = axios.create({
+  baseURL: "https://dust.tt/api/v1",
+  headers: {
+    Authorization: `Bearer ${DUST_API_KEY}`,
+    "Content-Type": "application/json",
+  },
+  maxContentLength: Infinity,
+  maxBodyLength: Infinity,
+});
+
+async function uploadCardsToDust() {
+  const guru = new Guru({
+    email: GURU_EMAIL,
+    token: GURU_API_TOKEN
+  });
+  const cards = await guru.getAllCards();
+  
+  console.log(`Processing ${cards.length} cards...`);
+  
+  // Use Bottleneck for rate limiting as in the original script
+  const limiter = new Bottleneck({
+    maxConcurrent: GURU_MAX_CONCURRENT,
+    minTime: 60 * 1000 / DUST_RATE_LIMIT,
+  });
+  
+  const tasks = cards.map((card: GuruCard) => {
+    return limiter.schedule(() => formatAndUploadCardToDust(card));
+  });
+  
+  await Promise.all(tasks);
+  console.log("All cards processed successfully.");
+}
+
+async function formatAndUploadCardToDust(card: GuruCard) {
+  
+  try {
+    // Create a section structure for Dust
+    const metadataSections = Object.keys(card).map(key => ({
+      prefix: key,
+      content: JSON.stringify(card[key]),
+      sections: []
+    }));
+    const section = {
+      prefix: card.id,
+      content: card.content,
+      sections: metadataSections
+    };
+    
+    // Upload to Dust
+    const documentId = `guru-card-${card.id}`;
+    await dustApi.post(
+      `/w/${DUST_WORKSPACE_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`,
+      {
+        section: section,
+        title: card.title,
+      }
+    );
+    
+    console.log(`Uploaded card "${card.title}" to Dust`);
+  } catch (error) {
+    console.error(`Error uploading card "${card.title}" to Dust:`, error);
+    throw error;
+  }
+}
+
+async function main() {
+  try{    
+    await uploadCardsToDust();
+    
+  } catch (error) {
+    console.error("An error occurred:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/guru/guru.ts
+++ b/guru/guru.ts
@@ -1,0 +1,244 @@
+import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
+
+export interface GuruCardRaw {
+    content: string
+    id: string
+    lastModified: string
+    owner: {
+        status: string
+        email: string
+        firstName: string
+        lastName: string
+        profilePicUrl: string
+    }
+    slug: string
+    collection: {
+        name: string
+        id: string
+        color: string
+        collectionType: string
+        publicCardsEnabled: boolean
+        roiEnabled: boolean
+    }
+    dateCreated: string
+    verifiers: GuruCardVerifiers
+
+    cardVerifier?: string
+
+    verificationInterval: number
+    lastVerified: string
+    lastVerifiedBy: {
+        status: string
+        email: string
+        firstName: string
+        lastName: string
+        profilePicUrl: string
+    }
+    lastModifiedBy: {
+        status: string
+        email: string
+        firstName: string
+        lastName: string
+        profilePicUrl: string
+    }
+    htmlContent: boolean
+    shareStatus: string
+    boards: Array<{
+        id: string
+        title: string
+        slug: string
+        items: any[]
+        numberOfFacts: number
+    }>
+    preferredPhrase: string
+    originalOwner: {
+        status: string
+        email: string
+        firstName: string
+        lastName: string
+        profilePicUrl: string
+    }
+    verificationState: string
+    verificationType: string
+    cardType: string
+    nextVerificationDate: string
+    cardInfo: {
+        analytics: {
+            unverifiedViews: number
+            boards: number
+            views: number
+            copies: number
+            unverifiedCopies: number
+            favorites: number
+        }
+    }
+}
+
+export interface GuruCardUserVerifier {
+    type: 'user'
+    user: {
+        status: string
+        email: string
+        firstName: string
+        lastName: string
+        profilePicUrl: string
+    }
+    id: string
+}
+
+export interface GuruCardGroupVerifier {
+    type: 'user-group'
+    userGroup: {
+        name: string
+        id: string
+        modifiable: boolean
+    }
+    id: string
+}
+
+export interface GroupMember {
+    id: string
+    user: {
+        status: string
+        email: string
+        lastName: string
+        firstName: string
+        profilePicUrl: string
+    }
+    dateCreated: string
+}
+
+export type GuruCardVerifiers = GuruCardUserVerifier[] | GuruCardGroupVerifier[]
+
+export interface GuruCard {
+    [key: string]: any
+    id: string
+    title: string
+    owner: string
+    firstName: string
+    lastName: string
+    verifier: string
+    collection: string
+    boards: string[]
+    content: string
+    verificationDate: string
+    verificationState: string
+    verificationInterval: number
+    link: string
+}
+
+export interface GuruConfig {
+    /** email of account to auth with */
+    email: string
+    /** API token generated from https://app.getguru.com/settings/api-access */
+    token: string
+}
+
+export class Guru {
+    private readonly email: string
+    private readonly token: string
+    private readonly httpConfig: AxiosRequestConfig
+
+    constructor(_config: GuruConfig) {
+        this.email = _config.email
+        this.token = _config.token
+
+        this.httpConfig = {
+            baseURL: 'https://api.getguru.com/api/v1',
+            auth: {
+                username: this.email,
+                password: this.token,
+            },
+        }
+    }
+
+    private async _request(
+        method: AxiosRequestConfig['method'],
+        url: string,
+        data?: any,
+        axiosOptions?: AxiosRequestConfig,
+    ): Promise<AxiosResponse> {
+        try {
+            const res = await axios(url, {
+                method,
+                data,
+                ...this.httpConfig,
+                ...(axiosOptions ?? {}),
+            })
+            return res
+        } catch (err: any) {
+            if (err.response.status === 401) {
+                throw new Error('Could not authenticate to Guru, check credentials and try again.')
+            }
+            throw err
+        }
+    }
+
+    _convertCardModel(cardRaw: GuruCardRaw): GuruCard {
+        return {
+            id: cardRaw.id,
+            title: cardRaw.preferredPhrase,
+            owner: cardRaw?.owner?.email ?? this.email,
+            firstName: cardRaw.owner.firstName,
+            lastName: cardRaw.owner.lastName,
+            verifier: cardRaw?.cardVerifier ?? '',
+            collection: cardRaw.collection.name,
+            boards: cardRaw.boards ? cardRaw.boards.map((board) => board.title) : [],
+            content: cardRaw.content,
+            verificationDate: cardRaw.nextVerificationDate,
+            verificationState: cardRaw.verificationState,
+            verificationInterval: cardRaw.verificationInterval,
+            link: `https://app.getguru.com/card/${cardRaw.slug}`,
+        }
+    }
+
+    async getGroupMembers(groupID: string): Promise<GroupMember[]> {
+        const res = await this._request('GET', `groups/${groupID}/members`)
+        return res.data
+    }
+
+    async getVerifier(verifiers: GuruCardVerifiers) {
+        let verifier = ''
+
+        if (verifiers[0]?.type === 'user-group') {
+            const groupID = verifiers[0]?.userGroup?.id
+
+            if (!groupID) return ''
+
+            const members = await this.getGroupMembers(groupID)
+
+            if (!members.length) return ''
+
+            verifier = members[0]?.user?.email
+        } else {
+            verifier = verifiers?.length ? verifiers[0]?.user?.email : this.email
+        }
+
+        return verifier
+    }
+
+    async getAllCardsRaw() {
+        const allCards: GuruCardRaw[] = []
+
+        // get first page of articles and push into final array
+        let res = await this._request('POST', '/search/cardmgr', {})
+
+        do {
+            allCards.push(...res.data)
+            const pageLink = res?.headers?.link?.match(/(?<=<)(.*)(?=>)/gs)![0]
+            if (!pageLink) break
+            res = await this._request('POST', pageLink, {})
+        } while (res?.headers?.link)
+
+        for (const card of allCards) {
+            card.cardVerifier = await this.getVerifier(card.verifiers)
+        }
+
+        return allCards
+    }
+
+    async getAllCards(): Promise<GuruCard[]> {
+        const allCards = await this.getAllCardsRaw()
+        return allCards.map(this._convertCardModel)
+    }
+}

--- a/guru/package.json
+++ b/guru/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "guru-to-dust-sync",
+    "version": "1.0.0",
+    "description": "Sync Guru data to Dust data sources",
+    "main": "guru-to-dust.ts",
+    "scripts": {
+        "sync": "ts-node guru-to-dust.ts",
+        "build": "tsc"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "axios": "^1.8.3",
+        "bottleneck": "^2.19.5",
+        "dotenv": "^16.3.1"
+    },
+    "devDependencies": {
+        "@eslint/js": "^9.22.0",
+        "@types/node": "^20.9.0",
+        "@typescript-eslint/eslint-plugin": "^6.10.0",
+        "@typescript-eslint/parser": "^6.10.0",
+        "eslint": "^8.57.1",
+        "globals": "^16.0.0",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.2.2",
+        "typescript-eslint": "^8.26.1"
+    }
+}

--- a/guru/readme.md
+++ b/guru/readme.md
@@ -1,0 +1,161 @@
+# Guru to Dust Data Sync
+
+This script is a Node.js application designed to sync Guru cards into Dust datasources. It fetches all cards from your Guru knowledge base and uploads them to a specified Dust datasource while maintaining their structure and content.
+
+## Usage example
+
+Example of a Guru card added to the Dust datasource:
+
+```
+Card ID: 6a7b8c9d-1234-5678-90ab-cdef12345678
+
+Title: Setting Up Two-Factor Authentication
+Owner: jane.smith@company.com
+First Name: Jane
+Last Name: Smith
+Verifier: john.doe@company.com
+Collection: Security Guidelines
+Boards: 
+  - Security Best Practices
+  - Employee Onboarding
+Verification Date: 2024-03-18T15:30:00.000Z
+Verification State: verified
+Verification Interval: 90
+Link: https://app.getguru.com/card/6a7b8c9d-1234-5678-90ab-cdef12345678
+
+Content:
+# Setting Up Two-Factor Authentication
+
+Two-factor authentication (2FA) adds an extra layer of security to your account. 
+Follow these steps to enable 2FA:
+
+1. Log into your account settings
+2. Navigate to Security > Two-Factor Authentication
+3. Choose your preferred 2FA method:
+   - Authenticator app (recommended)
+   - SMS verification
+   - Security key
+4. Follow the setup wizard to complete configuration
+
+Remember to save your backup codes in a secure location.
+```
+
+## Features
+
+- Bulk synchronization of all Guru cards
+- Preserves card metadata including:
+  - Card ID and title
+  - Collection and board information
+  - Owner and verifier details
+  - Verification status
+  - Last modified and verification dates
+  - Tags and categories
+- Rate limiting for both Guru and Dust APIs
+- Concurrent processing with configurable limits
+- Detailed logging and error handling
+
+## Prerequisites
+
+- Node.js (version 14 or higher)
+- npm (Node Package Manager)
+- Guru account with API access
+- Dust account with API access
+
+## Installation
+
+1. Clone the repository:
+   ```bash
+   git clone git@github.com:dust-tt/dust-labs.git
+   cd dust-labs
+   cd guru
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Create a `.env` file.
+
+### Environment Variables Explained
+
+#### Guru Credentials
+- `GURU_API_TOKEN`: Your Guru API token
+  - Found in Guru under Settings > API & Integrations
+  - Format: Starts with 'gku_'
+  - Required for authenticating with the Guru API
+
+- `GURU_EMAIL`: Your Guru account email
+  - Must match the email associated with the API token
+  - Used for API authentication
+
+#### Dust Credentials
+- `DUST_API_KEY`: Your Dust API key
+  - Found in your Dust account settings
+  - Format: Starts with 'sk-'
+  - Required for authenticating with the Dust API
+
+- `DUST_WORKSPACE_ID`: Your Dust workspace identifier
+  - Found in your Dust workspace URL or settings
+  - Format: ws-xxxxxxxxx
+  - Identifies which workspace to sync data to
+
+- `DUST_DATASOURCE_ID`: Your Dust datasource identifier
+  - Format: ds-xxxxxxxxx
+  - Specifies which datasource will store the Guru cards
+
+#### Rate Limiting Configuration
+- `DUST_RATE_LIMIT`: Maximum requests per minute to Dust API
+  - Adjust based on your Dust API tier
+  - Prevents API rate limit errors
+
+- `GURU_MAX_CONCURRENT`: Maximum concurrent card processing operations
+  - Adjust based on your system resources
+  - Controls parallel processing of Guru cards
+
+## Usage
+
+To run the script:
+
+```bash
+npm run sync
+```
+
+The script will:
+1. Validate environment variables
+2. Connect to Guru and fetch all cards
+3. Process each card concurrently (respecting rate limits)
+4. Upload formatted data to your Dust datasource
+
+## How It Works
+
+1. The script authenticates with Guru using the provided email and API token
+2. It retrieves all cards from your Guru knowledge base
+3. Each card is processed and formatted into a hierarchical structure:
+   - Metadata section containing card properties
+   - Content section with the actual card content
+4. The formatted data is uploaded to Dust using unique document IDs
+5. Rate limiting is applied to respect both Guru and Dust API constraints
+
+## Rate Limiting
+
+The script implements rate limiting using Bottleneck:
+- Concurrent operations: Controlled by `GURU_MAX_CONCURRENT`
+- Dust API rate limit: Controlled by `DUST_RATE_LIMIT`
+- Automatic queue management and retry logic
+
+## Error Handling
+
+The script includes comprehensive error handling:
+- Validates required environment variables
+- Handles API rate limits and retries
+- Provides detailed error logging
+- Continues processing on individual card failures
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the ISC License.

--- a/guru/tsconfig.json
+++ b/guru/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
+} 


### PR DESCRIPTION
### Summary
* Sync all Guru cards related to email into a provided dust data source
* Example output can be found in: https://dust.tt/w/Wf7PobEL3O/spaces/vlt_wFfpJA77nFxD/categories/folder/data_source_views/dsv_Bfj3oTFFJ7MT
* This currently only adds all the metadata related to cards. Happy to add additional filters and other entities based on request.
* Guru API limits were not documented. There is a (likely out of date) community post regarding limits here: https://community.getguru.com/api-integrations-7/api-rate-limit-6425 - No limit issues were found during testing. The concurrency / rate is configurable for users.