### PR TITLE
Add dropbox to dust script

### DIFF
--- a/dropbox/README.md
+++ b/dropbox/README.md
@@ -1,10 +1,10 @@
 # Dropbox to Dust Data Sync
 
-This script is a Node.js application designed to sync Dropbox files (including Paper docs) into Dust datasources. It fetches all files from your Dropbox account, optionally filtering by extension (e.g., `.paper`, `.md`, `.docx`), exports their content, and uploads them to a specified Dust datasource while maintaining their structure and content.
+This script is a Node.js application designed to sync Dropbox files (including Paper docs) into Dust datasources. It fetches all files from your Dropbox account, filtering by extension (e.g., `.paper`, `.md`, `.docx`, `.txt`), exports their content, and uploads them to a specified Dust datasource while maintaining their structure and content.
 
 ## Features
 
-- Bulk synchronization of all Dropbox files (optionally filter by extension)
+- Bulk synchronization of Dropbox files filtered by extension
 - Supports Dropbox Paper docs, Markdown, Word, and other file types
 - Preserves file metadata including:
   - File ID and name
@@ -74,7 +74,7 @@ To use this script, you need to create a Dropbox API app and generate an access 
 - `DUST_WORKSPACE_ID`: Your Dust workspace identifier
 - `DUST_DATASOURCE_ID`: Your Dust datasource identifier. This can be found by clicking `...` on your folder in the Dust console then `Use from API`.
 - `DUST_SPACE_ID`: Your Dust space identifier
-- `DROPBOX_EXTENSION_FILTER`: (Optional) File extension to filter by (e.g., `.paper`, `.md`, `.docx`). If not set, all files are synced.
+- `DROPBOX_EXTENSION_FILTER`: File extension to filter by (e.g., `.paper`, `.md`, `.docx`)
 - `DROPBOX_ROOT_PATH`: (Optional) Dropbox folder path to start from. Defaults to root (`""`).
 - `DUST_RATE_LIMIT`: (Optional, default 120) Maximum requests per minute to Dust API.
 - `DROPBOX_MAX_CONCURRENT`: (Optional) Maximum concurrent Dropbox file processing operations
@@ -111,7 +111,7 @@ npm run sync -- --ext .paper
 
 The script will:
 1. Validate environment variables
-2. Connect to Dropbox and fetch all files (optionally filter by extension)
+2. Connect to Dropbox and fetch all files matching the specified extension
 3. Export and process each file
 4. Upload formatted data to your Dust datasource
 

--- a/dropbox/README.md
+++ b/dropbox/README.md
@@ -1,0 +1,137 @@
+# Dropbox to Dust Data Sync
+
+This script is a Node.js application designed to sync Dropbox files (including Paper docs) into Dust datasources. It fetches all files from your Dropbox account, optionally filtering by extension (e.g., `.paper`, `.md`, `.docx`), exports their content, and uploads them to a specified Dust datasource while maintaining their structure and content.
+
+## Features
+
+- Bulk synchronization of all Dropbox files (optionally filter by extension)
+- Supports Dropbox Paper docs, Markdown, Word, and other file types
+- Preserves file metadata including:
+  - File ID and name
+  - Path and parent folder
+  - Created and updated dates
+- Rate limiting for both Dropbox and Dust APIs
+- Concurrent processing with configurable limits
+
+## Prerequisites
+
+- Node.js (version 14 or higher)
+- npm (Node Package Manager)
+- Dropbox account with API access
+- Dust account with API access
+
+## Installation
+
+1. Clone the repository:
+   ```bash
+   git clone git@github.com:dust-tt/dust-labs.git
+   cd dust-labs
+   cd dropbox
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Create a `.env` file.
+
+**Main script file:** The entry point for syncing is `dropbox-to-dust.ts`. All commands and npm scripts reference this file.
+
+## Creating Dropbox API Credentials and Required Permissions
+
+To use this script, you need to create a Dropbox API app and generate an access token with the correct permissions.
+
+### Steps to Create Dropbox API Credentials
+
+1. **Go to the Dropbox App Console:**
+   - Visit https://www.dropbox.com/developers/apps
+
+2. **Create a new app:**
+   - Click "Create App".
+   - Choose "Scoped access".
+   - Choose "Full dropbox" (or "App folder" if you want to restrict access to a specific folder).
+   - Name your app and create it.
+
+3. **Configure permissions (scopes):**
+   - In your app's settings, go to the "Permissions" tab.
+   - Enable the following scopes:
+     - `files.metadata.read`
+     - `files.content.read`
+     - `files.content.write` (if you want to support future write operations)
+     - `files.export` (for exporting Dropbox Paper docs)
+   - Click "Submit" at the bottom to save your changes.
+
+4. **Generate an access token:**
+   - In the "Settings" tab, scroll down to "OAuth 2".
+   - Click "Generate access token" (for personal use/testing) or implement the OAuth flow for production.
+   - Copy the generated token and use it as your `DROPBOX_API_KEY` in the `.env` file.
+
+### Environment Variables Explained
+
+- `DROPBOX_API_KEY`: Your Dropbox API token
+- `DUST_API_KEY`: Your Dust API key
+- `DUST_WORKSPACE_ID`: Your Dust workspace identifier
+- `DUST_DATASOURCE_ID`: Your Dust datasource identifier. This can be found by clicking `...` on your folder in the Dust console then `Use from API`.
+- `DUST_SPACE_ID`: Your Dust space identifier
+- `DROPBOX_EXTENSION_FILTER`: (Optional) File extension to filter by (e.g., `.paper`, `.md`, `.docx`). If not set, all files are synced.
+- `DROPBOX_ROOT_PATH`: (Optional) Dropbox folder path to start from. Defaults to root (`""`).
+- `DUST_RATE_LIMIT`: (Optional, default 120) Maximum requests per minute to Dust API.
+- `DROPBOX_MAX_CONCURRENT`: (Optional) Maximum concurrent Dropbox file processing operations
+
+**To sync only Dropbox Paper docs:**
+- Set `DROPBOX_EXTENSION_FILTER=.paper` in your `.env`, or
+- Run the script with `npm run sync -- --ext .paper`
+
+## Usage
+
+To run the script (sync all files):
+
+```bash
+npx tsx dropbox-to-dust.ts
+```
+
+Or, using npm (recommended):
+
+```bash
+npm run sync
+```
+
+To filter by extension (e.g., only Dropbox Paper docs):
+
+```bash
+npx tsx dropbox-to-dust.ts --ext .paper
+```
+
+Or, using npm:
+
+```bash
+npm run sync -- --ext .paper
+```
+
+The script will:
+1. Validate environment variables
+2. Connect to Dropbox and fetch all files (optionally filter by extension)
+3. Export and process each file
+4. Upload formatted data to your Dust datasource
+
+## How It Works
+
+1. The script authenticates with Dropbox using the provided API token
+2. It lists all files in your Dropbox (optionally under a specific folder)
+3. Optionally filters files by the specified extension
+4. Exports the content of each file (using Dropbox export API for Paper docs)
+5. Formats and uploads the data to Dust using unique document IDs
+6. Rate limiting is applied to respect both Dropbox and Dust API constraints
+
+## Error Handling
+
+The script includes comprehensive error handling:
+- Validates required environment variables
+- Handles API rate limits and retries
+- Provides detailed error logging
+- Continues processing on individual file failures
+
+## License
+
+This project is licensed under the ISC License. 

--- a/dropbox/dropbox-to-dust.ts
+++ b/dropbox/dropbox-to-dust.ts
@@ -1,0 +1,270 @@
+import axios, { AxiosResponse } from 'axios';
+import * as dotenv from 'dotenv';
+import Bottleneck from 'bottleneck';
+import path from 'path';
+
+dotenv.config();
+
+// Dropbox API
+const DROPBOX_API_KEY = process.env.DROPBOX_API_KEY;
+const DROPBOX_ROOT_PATH = process.env.DROPBOX_ROOT_PATH || '';
+const DROPBOX_EXTENSION_FILTER = process.env.DROPBOX_EXTENSION_FILTER;
+const DROPBOX_MAX_CONCURRENT = 2; // tuned for rate limits
+
+// Dust API
+const DUST_API_KEY = process.env.DUST_API_KEY;
+const DUST_WORKSPACE_ID = process.env.DUST_WORKSPACE_ID;
+const DUST_SPACE_ID = process.env.DUST_SPACE_ID;
+const DUST_DATASOURCE_ID = process.env.DUST_DATASOURCE_ID;
+const DUST_RATE_LIMIT = parseInt(process.env.DUST_RATE_LIMIT || '120');
+
+const MAX_DUST_TEXT_SIZE = 1024 * 1024; // 1MB
+const SPLIT_OVERLAP = 200; // chars of overlap between splits for context
+
+// CLI arg for extension filter
+const extArgIdx = process.argv.indexOf('--ext');
+const EXTENSION = extArgIdx !== -1 && process.argv[extArgIdx + 1] ? process.argv[extArgIdx + 1] : DROPBOX_EXTENSION_FILTER;
+
+// Validate required env vars
+const missingEnvVars = [
+  ['DROPBOX_API_KEY', DROPBOX_API_KEY],
+  ['DUST_API_KEY', DUST_API_KEY],
+  ['DUST_WORKSPACE_ID', DUST_WORKSPACE_ID],
+  ['DUST_SPACE_ID', DUST_SPACE_ID],
+  ['DUST_DATASOURCE_ID', DUST_DATASOURCE_ID],
+].filter(([name, value]) => !value).map(([name]) => name);
+
+if (missingEnvVars.length > 0) {
+  throw new Error(`Please provide values for the following environment variables in the .env file: ${missingEnvVars.join(', ')}`);
+}
+
+// Dropbox API client (metadata)
+const dropboxApi = axios.create({
+  baseURL: 'https://api.dropboxapi.com/2',
+  headers: {
+    'Authorization': `Bearer ${DROPBOX_API_KEY}`,
+    'Content-Type': 'application/json',
+  },
+});
+
+// Dropbox Content API client (for export/download)
+const dropboxContentApi = axios.create({
+  baseURL: 'https://content.dropboxapi.com/2',
+  headers: {
+    'Authorization': `Bearer ${DROPBOX_API_KEY}`,
+  },
+  responseType: 'text',
+});
+
+// Add Dropbox 429 rate limit handling
+const RETRY_DELAY_MS = 2000;
+dropboxContentApi.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error.response && error.response.status === 429) {
+      console.error('Dropbox rate limit hit. Backing off for 2s and retrying...');
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      return dropboxContentApi.request(error.config);
+    }
+    return Promise.reject(error);
+  }
+);
+
+dropboxApi.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error.response && error.response.status === 429) {
+      console.error('Dropbox rate limit hit (metadata). Backing off for 2s and retrying...');
+      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+      return dropboxApi.request(error.config);
+    }
+    return Promise.reject(error);
+  }
+);
+
+// Dust API client
+const dustApi = axios.create({
+  baseURL: 'https://dust.tt/api/v1',
+  headers: {
+    'Authorization': `Bearer ${DUST_API_KEY}`,
+    'Content-Type': 'application/json',
+  },
+  maxContentLength: Infinity,
+  maxBodyLength: Infinity,
+});
+
+// Rate limiters
+// This allows up to (1000ms / 150ms) * 2 ≈ 13 requests/second (theoretical max, but concurrency is usually limited by I/O)
+const DROPBOX_REQUESTS_PER_SECOND = 6; // Target requests per second
+const dropboxLimiter = new Bottleneck({
+  maxConcurrent: DROPBOX_MAX_CONCURRENT,
+  minTime: Math.ceil(1000 / DROPBOX_REQUESTS_PER_SECOND),
+});
+const dustLimiter = new Bottleneck({
+  minTime: Math.ceil(60000 / DUST_RATE_LIMIT),
+  maxConcurrent: 1,
+});
+
+const limitedDropboxRequest = dropboxLimiter.wrap((config: any) => dropboxApi.request(config));
+const limitedDropboxContentRequest = dropboxLimiter.wrap((config: any) => dropboxContentApi.request(config));
+const limitedDustRequest = dustLimiter.wrap((config: any) => dustApi.request(config));
+
+interface DropboxFileMetadata {
+  id: string;
+  name: string;
+  path_display: string;
+  client_modified: string;
+  server_modified: string;
+  is_paper_doc?: boolean;
+  [key: string]: any;
+}
+
+async function listAllFiles(folderPath: string, extension: string | undefined): Promise<DropboxFileMetadata[]> {
+  let hasMore = true;
+  let cursor: string | null = null;
+  let files: DropboxFileMetadata[] = [];
+
+  while (hasMore) {
+    let res: AxiosResponse<any>;
+    if (!cursor) {
+      res = await limitedDropboxRequest({
+        method: 'POST',
+        url: '/files/list_folder',
+        data: {
+          path: folderPath,
+          recursive: true,
+          include_media_info: false,
+          include_deleted: false,
+          include_has_explicit_shared_members: false,
+          include_mounted_folders: true,
+        },
+      });
+    } else {
+      res = await limitedDropboxRequest({
+        method: 'POST',
+        url: '/files/list_folder/continue',
+        data: { cursor },
+      });
+    }
+    let entries = res.data.entries.filter((entry: any) => entry['.tag'] === 'file');
+    if (extension) {
+      entries = entries.filter((entry: any) => entry.name.endsWith(extension));
+    }
+    files = files.concat(entries);
+    hasMore = res.data.has_more;
+    cursor = res.data.cursor;
+  }
+  return files;
+}
+
+async function exportDropboxFile(file: DropboxFileMetadata): Promise<{ content: string; format: string }> {
+  // Match .paper, .papert, etc.
+  const isPaperDoc = file.name.endsWith('.paper') || file.name.endsWith('.papert');
+  const contentHeaders = {
+    'Authorization': `Bearer ${DROPBOX_API_KEY}`,
+    'Dropbox-API-Arg': JSON.stringify(
+      isPaperDoc
+        ? { path: file.path_display, export_format: 'markdown' }
+        : { path: file.path_display }
+    ),
+    'Content-Type': 'text/plain',
+  };
+
+  if (isPaperDoc) {
+    // Use Dropbox Content API for export
+    const res = await limitedDropboxContentRequest({
+      method: 'POST',
+      url: '/files/export',
+      headers: contentHeaders,
+      data: null,
+      responseType: 'text',
+    });
+    return { content: res.data, format: 'markdown' };
+  } else {
+    // For other files, use /files/download via Content API
+    const res = await limitedDropboxContentRequest({
+      method: 'POST',
+      url: '/files/download',
+      headers: contentHeaders,
+      data: null,
+      responseType: 'text',
+    });
+    return { content: res.data, format: path.extname(file.name).replace('.', '') };
+  }
+}
+
+function splitContentForDust(text: string, maxSize: number, overlap: number): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = start + maxSize;
+    if (end > text.length) end = text.length;
+    let part = text.slice(start, end);
+    parts.push(part);
+    if (end === text.length) break;
+    start = end - overlap; // overlap for context
+    if (start < 0) start = 0;
+  }
+  return parts;
+}
+
+async function upsertToDustDatasource(file: DropboxFileMetadata, content: string, format: string) {
+  const baseDocumentId = `${file.name}`;
+  const metadata = [
+    `File Name: ${file.name}`,
+    `Path: ${file.path_display}`,
+    `File ID: ${file.id}`,
+    `Client Modified: ${file.client_modified}`,
+    `Server Modified: ${file.server_modified}`,
+    `Format: ${format}`,
+  ].join('\n');
+
+  const baseText = `---\n${metadata}\n---\n\n`;
+  const maxContentSize = MAX_DUST_TEXT_SIZE - Buffer.byteLength(baseText, 'utf8');
+  const contentParts = splitContentForDust(content, maxContentSize, SPLIT_OVERLAP);
+
+  for (let i = 0; i < contentParts.length; i++) {
+    const partText = baseText + contentParts[i];
+    const documentId = contentParts.length === 1 ? baseDocumentId : `${baseDocumentId}-part${i + 1}`;
+    const partMeta = contentParts.length === 1 ? '' : `\n(Part ${i + 1} of ${contentParts.length})`;
+    const textWithPart = partText + partMeta;
+    if (Buffer.byteLength(textWithPart, 'utf8') > MAX_DUST_TEXT_SIZE) {
+      console.warn(`[SKIP] Even split part for ${file.name} exceeds Dust 1MB text limit. Skipping part ${i + 1}.`);
+      continue;
+    }
+    const url = `/w/${DUST_WORKSPACE_ID}/spaces/${DUST_SPACE_ID}/data_sources/${DUST_DATASOURCE_ID}/documents/${documentId}`;
+    await limitedDustRequest({
+      method: 'POST',
+      url,
+      data: {
+        text: textWithPart,
+        source_url: `https://www.dropbox.com/home${file.path_display}`,
+      },
+    });
+    console.log(`[UPLOADED] ${file.name} part ${i + 1}/${contentParts.length} as ${documentId}`);
+  }
+}
+
+async function main() {
+  console.log(`Syncing Dropbox files${EXTENSION ? ` with extension '${EXTENSION}'` : ''} to Dust datasource...`);
+  try {
+    const files = await listAllFiles(DROPBOX_ROOT_PATH, EXTENSION || undefined);
+    console.log(`Found ${files.length} files${EXTENSION ? ` with extension '${EXTENSION}'` : ''}.`);
+    let processed = 0;
+    for (const file of files) {
+      try {
+        const { content, format } = await exportDropboxFile(file);
+        await upsertToDustDatasource(file, content, format);
+        processed++;
+        console.log(`[${processed}/${files.length}] Synced: ${file.name}`);
+      } catch (err) {
+        console.error(`Error processing file ${file.name}:`, err);
+      }
+    }
+    console.log('All files processed.');
+  } catch (err) {
+    console.error('An error occurred:', err);
+  }
+}
+
+main(); 

--- a/dropbox/example.env
+++ b/dropbox/example.env
@@ -1,0 +1,18 @@
+# Dropbox API credentials
+DROPBOX_API_KEY=your_dropbox_api_key
+
+# Dust API credentials
+DUST_API_KEY=your_dust_api_key
+DUST_WORKSPACE_ID=your_dust_workspace_id
+DUST_DATASOURCE_ID=your_dust_datasource_id
+DUST_SPACE_ID=your_dust_space_id
+
+# Extension filter (optional, examples: .paper, .md, .docx)
+DROPBOX_EXTENSION_FILTER=.paper
+
+# Dropbox root path (optional, default is root)
+DROPBOX_ROOT_PATH=
+
+# Rate limiting and concurrency (optional)
+DUST_RATE_LIMIT=120
+DROPBOX_MAX_CONCURRENT=5 

--- a/dropbox/package.json
+++ b/dropbox/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dropbox-to-dust",
+  "version": "0.1.0",
+  "description": "Script to synchronise Dropbox files (including Paper docs) to Dust datasources",
+  "main": "dropbox-to-dust.ts",
+  "scripts": {
+    "sync": "tsx dropbox-to-dust.ts",
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^1.4.0",
+    "dotenv": "^16.0.3",
+    "bottleneck": "^2.19.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4",
+    "tsx": "^4.19.1",
+    "@types/node": "^18.16.3"
+  }
+} 


### PR DESCRIPTION
## Summary
* Adding script that traverses dropbox and uploads data to Dust. Able to filter by folder and file extension.

## Testing

Test folder: https://dust.tt/w/0ec9852c2f/spaces/vlt_ZqMdUAzI0OTf/categories/folder/data_source_views/dsv_9UFRqHD3UeWZg

```
aloia@Franks-MacBook-Pro dropbox % npm run sync   

> dropbox-to-dust@0.1.0 sync
> tsx dropbox-to-dust.ts

Syncing Dropbox files to Dust datasource...
Found 2 files.
[UPLOADED] _ Getting Started with Dropbox Paper.paper part 1/1 as _ Getting Started with Dropbox Paper.paper
[1/2] Synced: _ Getting Started with Dropbox Paper.paper
[UPLOADED] _ My Paper doc.papert part 1/1 as _ My Paper doc.papert
[2/2] Synced: _ My Paper doc.papert
All files processed.
```