### PR TITLE
Fix comments URL construction for GSheet script

### DIFF
--- a/google/spreadsheet/dust-app-script.js
+++ b/google/spreadsheet/dust-app-script.js
@@ -887,7 +887,7 @@ function processWithAssistant(
           });
 
         const appUrl =
-          "https://dust.tt/w/" +
+          getDustBaseUrl() + "/w/" +
           workspaceId +
           "/assistant/" +
           result.conversation.sId;


### PR DESCRIPTION
Construct the Dust app script URL by calling the `getDustBaseUrl()` function instead of hardcoding the base URL to ensure the URL is constructed correctly, regardless of the environment or configuration.